### PR TITLE
Fix aarch64 architecture recognition

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -27,9 +27,11 @@ with builtins; rec {
     else if system == "i686-darwin" then
       lib.findFirst ({host, ...}: (match "i[3456]86-apple-darwin.*" host) != null) null systems
     else if system == "aarch64-linux" then
-      lib.findFirst ({host, ...}: (match "(aarch64|arm64)-linux-gnu" host) != null) null systems
+      # tools.go uses regexp.MatchString which will also return true for substring matches, so we add a .* to the regex
+      lib.findFirst ({host, ...}: (match "(aarch64|arm64)-linux-gnu.*" host) != null) null systems
     else if system == "x86_64-linux" then
-      lib.findFirst ({host, ...}: (match "x86_64-.*linux-gnu" host) != null) null systems
+      # also add a .* to the regex here though it is not necessary in the current dataset (March 2024)
+      lib.findFirst ({host, ...}: (match "x86_64-.*linux-gnu.*" host) != null) null systems
     else null;
   convertHash = hash: let
     m = (match "(SHA-256|SHA-1|MD5):(.*)" hash);


### PR DESCRIPTION
When trying to use `arduino-nix` for building a `aarch64-linux` nixos I got
```
error: Unsupported platform aarch64-linux
```
even when using an empty
```
pkgs.wrapArduinoCLI {}
```

I discovered that the issue arises from one (or actually even multiple) of the `builtinPackages` in `wrap-arduino-cli.nix`. They are listed with `"host": "arm64-linux-gnueabihf"` in `package_index.json` which the `(aarch64|arm64)-linux-gnu` regex did not match.
Example: https://github.com/bouk/arduino-indexes/blob/464543eb2f8c234e764db01400230112c40a1c80/index/package_index.json#L13331C1-L13337C14

Also see the comment in the PRs code for further details.