### PR TITLE
WIP: Add ability to modify `platform.txt` via mkArduinoPackageOverlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,10 @@
   description = "Wrapper for arduino-cli";
 
   outputs = { self }: {
-    mkArduinoPackageOverlay = packageIndexFile: (self: super: {
+    mkArduinoPackageOverlay = { packageIndexFile, buildProperties ? {} }: (self: super: {
       arduinoPackages = self.lib.recursiveUpdate (super.arduinoPackages or {}) (self.callPackage ./packages.nix {
         packageIndex = builtins.fromJSON (builtins.readFile packageIndexFile);
+        buildProperties = buildProperties;
       });
     });
 

--- a/packages.nix
+++ b/packages.nix
@@ -60,7 +60,7 @@ let
         patchPhase = ''
         # Iterate over each key-value pair in buildProperties
         ${
-          pkgs.lib.concatStringsSep "\n" (mapAttrsToList (key: value: ''
+          pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (key: value: ''
             sed -i "s|^${key}=.*|${key}=\"${value}\"|" "$dirName/platform.txt"
           '') buildProperties)
         }

--- a/packages.nix
+++ b/packages.nix
@@ -1,4 +1,4 @@
-{ fetchzip, stdenv, lib, packageIndex, pkgsBuildHost, pkgs, arduinoPackages }:
+{ fetchzip, stdenv, lib, packageIndex, buildProperties, pkgsBuildHost, pkgs, arduinoPackages }:
 
 with builtins;
 let
@@ -56,6 +56,14 @@ let
           done
 
           runHook postInstall
+        '';
+        patchPhase = ''
+        # Iterate over each key-value pair in buildProperties
+        ${
+          pkgs.lib.concatStringsSep "\n" (mapAttrsToList (key: value: ''
+            sed -i "s|^${key}=.*|${key}=\"${value}\"|" "$dirName/platform.txt"
+          '') buildProperties)
+        }
         '';
         nativeBuildInputs = [ pkgs.unzip ];
         src = fetchurl ({

--- a/packages.nix
+++ b/packages.nix
@@ -64,7 +64,7 @@ let
             pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (key: value: ''
             if grep -q "^${key}=" "$out/$dirName/platform.txt"; then
               # If the line exists, use sed to replace it
-              sed -i "s|^${key}=.*|${key}=\"${value}\"|" "$out/$dirName/platform.txt"
+              sed -i "s|^${key}=.*|${key}=${value}|" "$out/$dirName/platform.txt"
             else
               # If the line doesn't exist, add it at the end of the file
               echo "${key}=${value}" >> "$out/$dirName/platform.txt"

--- a/packages.nix
+++ b/packages.nix
@@ -64,7 +64,7 @@ let
             pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (key: value: ''
             if grep -q "^${key}=" "$out/$dirName/platform.txt"; then
               # If the line exists, use sed to replace it
-              sed -i "s|^${key}=.*|${key}=${value}|" "$out/$dirName/platform.txt"
+              sed -i "s|^${key}=.*|& ${value}|" "$out/$dirName/platform.txt"
             else
               # If the line doesn't exist, add it at the end of the file
               echo "${key}=${value}" >> "$out/$dirName/platform.txt"

--- a/packages.nix
+++ b/packages.nix
@@ -57,7 +57,7 @@ let
 
           runHook postInstall
         '';
-        patchPhase = ''
+        fixupPhase = ''
         # Iterate over each key-value pair in buildProperties
         ${
           pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (key: value: ''

--- a/packages.nix
+++ b/packages.nix
@@ -61,7 +61,7 @@ let
         # Iterate over each key-value pair in buildProperties
         ${
           pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (key: value: ''
-            sed -i "s|^${key}=.*|${key}=\"${value}\"|" "$dirName/platform.txt"
+            sed -i "s|^${key}=.*|${key}=\"${value}\"|" "$out/$dirName/platform.txt"
           '') buildProperties)
         }
         '';

--- a/packages.nix
+++ b/packages.nix
@@ -57,19 +57,20 @@ let
 
           runHook postInstall
         '';
-        # Iterate over each key-value pair in buildProperties
-        # and append/update it accordingly in platform.txt
-        buildPropertiesFixupCommands = pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (key: value: ''
-          if grep -q "^${key}=" "$out/$dirName/platform.txt"; then
-            # If the line exists, use sed to replace it
-            sed -i "s|^${key}=.*|${key}=\"${value}\"|" "$out/$dirName/platform.txt"
-          else
-            # If the line doesn't exist, add it at the end of the file
-            echo "${key}=${value}" >> "$out/$dirName/platform.txt"
-          fi
-          '') buildProperties);
         fixupPhase = ''
-          ${buildPropertiesFixupCommands}
+          # Iterate over each key-value pair in buildProperties
+          # and append/update it accordingly in platform.txt
+          ${
+            pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (key: value: ''
+            if grep -q "^${key}=" "$out/$dirName/platform.txt"; then
+              # If the line exists, use sed to replace it
+              sed -i "s|^${key}=.*|${key}=\"${value}\"|" "$out/$dirName/platform.txt"
+            else
+              # If the line doesn't exist, add it at the end of the file
+              echo "${key}=${value}" >> "$out/$dirName/platform.txt"
+            fi
+            '') buildProperties)
+          }
         '';
         nativeBuildInputs = [ pkgs.unzip ];
         src = fetchurl ({


### PR DESCRIPTION
This PR adds a way to include an attribute set that modifies `platform.txt` located at `packages/${name}/hardware/${architecture}/${version}/platform.txt`. I created this feature as a way to sidestep some issues I encountered when compiling for the Digispark.

## Overview

The functionality allows you to provide the attrset argument called `buildProperties` to `mkArduinoPackageOverlay` in the same manner you would call:

```
arduino-cli --build-property KEY=VALUE
```

## Example

Calling `mkArduinoPackageOverlay` while specifying custom buildProperties looks like the following:

```nix
      (arduino-nix.mkArduinoPackageOverlay {
        packageIndexFile = (arduino-index + "/index/package_digistump_index.json");
        buildProperties = {
          "KEY1" = "VALUE1";
          "KEY2" = "VALUE2";
        };
      })
```

which corresponds to `platform.txt` looking like the following:

```
...
KEY1=VALUE1
KEY2=VALUE2
...
```

Note that, if the key did not already exist in platform.txt, it would be appended on a new line. Otherwise, it is appended to the same line with a space.

## The caveat (suggestions, anyone?)

Calling `mkArduinoPackageOverlay` without specifying any extra buildProperties would need to look like this now:

```diff
-(arduino-nix.mkArduinoPackageOverlay (arduino-index + "/index/package_index.json"))
+(arduino-nix.mkArduinoPackageOverlay { packageIndexFile = (arduino-index + "/index/package_index.json"); })
```

which is obviously non-optimal. I'm open to suggestions for how to make this better, as I'm still learning the nix lang.