### PR TITLE
Use pkgs.fetchurl instead of implicit builtins.fetchurl

### DIFF
--- a/libraries.nix
+++ b/libraries.nix
@@ -19,7 +19,7 @@ let
         runHook postInstall
       '';
       nativeBuildInputs = [ pkgs.unzip ];
-      src = fetchurl ({
+      src = pkgs.fetchurl ({
         url = url;
       } // (convertHash checksum));
     };

--- a/packages.nix
+++ b/packages.nix
@@ -26,7 +26,7 @@ let
               cp -R * "$out/$dirName/"
             '';
             nativeBuildInputs = [ pkgs.unzip ];
-            src = fetchurl ({
+            src = pkgs.fetchurl ({
               url = system.url;
             } // (convertHash system.checksum));
           };
@@ -58,7 +58,7 @@ let
           runHook postInstall
         '';
         nativeBuildInputs = [ pkgs.unzip ];
-        src = fetchurl ({
+        src = pkgs.fetchurl ({
           url = url;
         } // (convertHash checksum));
       };


### PR DESCRIPTION
We do not want or need these downloads at eval time, and it breaks eval/builds in memory-constrained environments.

Fixes https://github.com/bouk/arduino-nix/issues/10